### PR TITLE
Fix modal corners

### DIFF
--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -2,7 +2,13 @@ body {
   // background-color: $cream;
 }
 
-body, h1, h2, h3, h4, h5, h6 {
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   color: $dark;
 }
 
@@ -40,14 +46,19 @@ a:hover {
 
 .invert {
   background-color: $dark;
-  h1, h2, h3, h4, h5, p {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  p {
     color: white;
   }
 }
 
 .pill {
   display: inline-block;
-  padding: .125rem .25rem;
+  padding: 0.125rem 0.25rem;
   background-color: $green;
   font-size: $font-size-h4;
   border-radius: 4px;

--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -34,7 +34,7 @@ a:hover {
   border: 1px solid $dark;
 }
 .border-thick {
-  border-radius: 5px;
+  border-radius: 1px;
   border: 2px solid $dark;
 }
 


### PR DESCRIPTION
Fixes #9 

I noticed even the "sharp" corners have a 1px radius.
I tried 2px for the `.thick-border`, but it still looked a bit rounded, so I made it 1px like the `.thin-border` class.