### PR TITLE
Add loading animations to images

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "js-cookie": "^2.2.1",
     "moment": "^2.25.3",
     "quill": "^1.3.7",
+    "v-lazy-image": "^1.4.0",
     "vue": "^2.6.11",
     "vue-analytics": "^5.22.1",
     "vue-goodshare": "^1.5.1",

--- a/src/assets/images/spinner.svg
+++ b/src/assets/images/spinner.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+  style="margin: auto; display: block; shape-rendering: auto;" width="91px" height="91px" viewBox="0 0 100 100"
+  preserveAspectRatio="xMidYMid">
+  <circle cx="50" cy="50" fill="none" stroke="#F6F3EC" stroke-width="9" r="21"
+    stroke-dasharray="98.96016858807849 34.98672286269283">
+    <animateTransform attributeName="transform" type="rotate" repeatCount="indefinite" dur="2.2222222222222223s"
+      values="0 50 50;360 50 50" keyTimes="0;1"></animateTransform>
+  </circle>
+</svg>

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -12,7 +12,12 @@ export default {
   components: {
     LazyImg,
   },
-  props: ['profile'],
+  props: {
+    profile: {
+      type: Object,
+      required: true,
+    },
+  },
   computed: {
     avatarImg() {
       return this.profile.avatarUrl || require('@/assets/images/avatar.svg')

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,13 +1,17 @@
 <template>
   <div class="profile flex flex-center">
-    <img class="profile-avatar" :src="avatarImg" />
+    <LazyImg class="profile-avatar" :src="avatarImg" />
     <span class="small profile-name" @click="handleClick()">{{ profile.name }}</span>
   </div>
 </template>
 
 <script>
+import LazyImg from '@/components/LazyImg'
 export default {
   name: 'Hashtag',
+  components: {
+    LazyImg,
+  },
   props: ['profile'],
   computed: {
     avatarImg() {

--- a/src/components/CompanyCard.vue
+++ b/src/components/CompanyCard.vue
@@ -2,10 +2,10 @@
   <!-- <Card @click="handleClick(company)"> -->
   <Card>
     <template v-slot:logo>
-      <img v-if="company.logoUrl" class="company-logo" :src="getImageUrl(company.logoUrl)" />
+      <LazyImg v-if="company.logoUrl" class="company-logo" :src="getImageUrl(company.logoUrl)" />
     </template>
     <template v-slot:cover>
-      <img v-if="company.coverUrl" :src="getImageUrl(company.coverUrl)" />
+      <LazyImg v-if="company.coverUrl" :src="getImageUrl(company.coverUrl)" />
     </template>
     <template v-slot:default>
       <!-- Company Name -->
@@ -50,10 +50,11 @@ import { waitForLogin } from '@/mixins'
 import Icon from '@/components/Icon.vue'
 import Card from '@/components/Card.vue'
 import Hashtag from '@/components/Hashtag'
+import LazyImg from '@/components/LazyImg'
 
 export default {
   name: 'CompanyCard',
-  components: { Hashtag, Card, Icon },
+  components: { LazyImg, Hashtag, Card, Icon },
   props: {
     company: {
       type: Object,

--- a/src/components/CompanyCard.vue
+++ b/src/components/CompanyCard.vue
@@ -26,7 +26,7 @@
           :key="slug"
           :slug="slug"
           clickable
-          @click="$emit('hashtagClick', slug)"
+          @click="$emit('hashtag-click', slug)"
         />
       </div>
 
@@ -54,7 +54,12 @@ import Hashtag from '@/components/Hashtag'
 export default {
   name: 'CompanyCard',
   components: { Hashtag, Card, Icon },
-  props: ['company'],
+  props: {
+    company: {
+      type: Object,
+      required: true,
+    },
+  },
   data() {
     return {
       localClapCount: null,

--- a/src/components/LazyImg.vue
+++ b/src/components/LazyImg.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-lazy-image :src="src" :src-placeholder="require('@/assets/images/spinner.svg')" />
+</template>
+
+<script>
+import VLazyImage from 'v-lazy-image'
+
+export default {
+  components: {
+    VLazyImage,
+  },
+  props: {
+    src: {
+      type: String,
+      default: '',
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/Company.vue
+++ b/src/views/Company.vue
@@ -2,8 +2,8 @@
   <div class="wrapper sm-grid-sidebar-down">
     <div v-if="company" class="content">
       <div class="company-images">
-        <img class="logo" :src="company.logoUrl || defaultLogo" alt="Company Logo" />
-        <img class="cover" :src="company.coverUrl || defaultCover" alt="Company Cover Image" />
+        <lazy-img class="logo" :src="company.logoUrl || defaultLogo" alt="Company Logo" />
+        <lazy-img class="cover" :src="company.coverUrl || defaultCover" alt="Company Cover Image" />
       </div>
 
       <h1 class="mt-2">
@@ -74,6 +74,7 @@ import TwitterFeed from '../components/TwitterFeed.vue'
 import api from '@/api'
 import Discussion from '@/components/Discussion'
 import Hashtag from '@/components/Hashtag'
+import LazyImg from '@/components/LazyImg'
 import { waitForLogin } from '@/mixins'
 
 export default {
@@ -86,6 +87,7 @@ export default {
   },
   components: {
     Discussion,
+    LazyImg,
     Hashtag,
     Icon,
     SocialShare,

--- a/src/views/Person.vue
+++ b/src/views/Person.vue
@@ -4,7 +4,7 @@
       <div class="profile">
         <div class="profile-data">
           <div class="profile-image">
-            <img
+            <LazyImg
               :src="
                 profile.avatarUrl || 'https://avatars.dicebear.com/api/male/john.svg?mood[]=happy'
               "
@@ -54,6 +54,7 @@
 <script>
 import SocialShare from '../components/SocialShare.vue'
 import TwitterFeed from '../components/TwitterFeed.vue'
+import LazyImg from '../components/LazyImg.vue'
 import Icon from '../components/Icon.vue'
 import api from '@/api'
 
@@ -65,7 +66,7 @@ export default {
       title: () => (profile && profile.name ? profile.name : 'People'),
     }
   },
-  components: { Icon, TwitterFeed, SocialShare },
+  components: { Icon, LazyImg, TwitterFeed, SocialShare },
   props: {
     slug: { required: true, type: String },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11810,6 +11810,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+v-lazy-image@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/v-lazy-image/-/v-lazy-image-1.4.0.tgz#320b2bb90a02450bc78c32eaa12f1be36e60e2d5"
+  integrity sha512-Xp/fM786hdXlP10HatvtNsvvPjW6yOsH17lvVEEuGiNMnyiafT9XVomQRRM4t+IzN21cz3SQcw9cqd486yhpgQ==
+
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"


### PR DESCRIPTION
Created using [v-lazy-image](https://github.com/alexjoverm/v-lazy-image)
Still not perfect, as the SVG loader will enlarge with the image (visible in the company header, for example), but it's nothing serious.
We can later implement our own solution, or try another plugin to fix it. 

Fixes #33 