### PR TITLE
Redirect all api requests to staging except prod

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,5 +2,5 @@ https://aec.works/sitemap.xml                       https://api.aec.works/sitema
 https://aec.works/api/*                             https://api.aec.works/:splat                            200
 https://aec.works/*                                 https://aec.works/                                      200
 
-https://staging--aecworks.netlify.app/api/*         https://aecworks-api-staging.herokuapp.com/:splat       200
-https://staging--aecworks.netlify.app/*             https://staging--aecworks.netlify.app/                  200
+/api/*                                              https://aecworks-api-staging.herokuapp.com/:splat       200
+/*                                                  /                                                       200


### PR DESCRIPTION
Fixes #26 

* All front end request except prod redirect to staging api
* backend change was to add `*.netlify.app` as CSRF trusted origin


### Test

https://deploy-preview-35--aecworks.netlify.app/companies

![image](https://user-images.githubusercontent.com/9513968/94892864-b23eb380-043a-11eb-816f-654d12131a7b.png)
