### PR TITLE
make both x and y have overflow:hidden

### DIFF
--- a/src/components/SocialIcons.vue
+++ b/src/components/SocialIcons.vue
@@ -57,7 +57,7 @@ export default {
     @include shadow-color($dark);
   }
 
-  overflow-y: hidden;
+  overflow: hidden;
   height: 32px;
   max-width: 32px;
   transition: max-width 200ms ease-in-out;


### PR DESCRIPTION
Simple fix to remove the scrollbar on all browsers (was previously showing on Edge).