### PR TITLE
Change Companies loader to overlay

### DIFF
--- a/src/assets/scss/_helpers.scss
+++ b/src/assets/scss/_helpers.scss
@@ -135,6 +135,10 @@
   display: block;
 }
 
+.relative {
+  position: relative;
+}
+
 .section {
   padding: 1rem 2rem;
 }

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -46,7 +46,7 @@ export default {
   display: flex;
   flex-direction: column;
   margin-bottom: 2rem;
-  width: 100%;
+  width: 99%; // compensated for the shadow
   z-index: 1;
 
   @extend .border-thin;

--- a/src/views/CompanyList.vue
+++ b/src/views/CompanyList.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="wrapper">
-    <div class="content">
-      <Loader v-if="isLoading" />
+    <div class="content relative">
+      <div v-if="isLoading" class="loader-overlay">
+        <Loader />
+      </div>
 
       <CompanyCard
         v-for="company in items"
@@ -139,12 +141,10 @@ export default {
   methods: {
     refetch() {
       this.$router.replace({ query: { ...this.$route.query, page: 1 } }).catch(() => {})
-      this.items = []
       this.fetchItems(0)
     },
 
     async fetchItems(pageNumber) {
-      this.items = []
       this.isLoading = true
       let query = {
         page: pageNumber,
@@ -245,5 +245,18 @@ export default {
       color: $dark;
     }
   }
+}
+
+.loader-overlay {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.8);
+  padding-top: 4rem;
 }
 </style>


### PR DESCRIPTION
Currently, every time we do a refetch, the list disappears and a loader comes up, making the page "jump" because of the scrollbars.

This PR proposes to keep the current list on while the refetch is done. The loader becomes an overlay on top of the company cards, which are then updated when the loading is complete.