### PR TITLE
refactor: implement sorting component

### DIFF
--- a/src/assets/images/arrow-down.svg
+++ b/src/assets/images/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <path fill-rule="evenodd" d="M14.707 12.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+</svg>

--- a/src/assets/images/arrow-up.svg
+++ b/src/assets/images/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <path fill-rule="evenodd" d="M5.293 7.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L6.707 7.707a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+</svg>

--- a/src/components/Sorting.vue
+++ b/src/components/Sorting.vue
@@ -23,10 +23,11 @@
 import { popQuery } from '@/utils'
 
 export default {
-  data() {
-    return {
-      sortingOptions: ['claps', 'name', 'updated'],
-    }
+  props: {
+    sortingOptions: {
+      type: Array,
+      required: true,
+    },
   },
   methods: {
     getSortStyle(sortBy) {

--- a/src/components/Sorting.vue
+++ b/src/components/Sorting.vue
@@ -1,0 +1,99 @@
+<template>
+  <div>
+    <label class="mt-1">Sorting</label>
+    <div class="sorting-options fill-x">
+      <ul>
+        <li
+          v-for="paramName in sortingOptions"
+          :key="paramName"
+          class="pointer small"
+          :class="getSortStyle(paramName)"
+          @click="handleSortChange(paramName)"
+        >
+          <img class="arrow-down" :src="require(`@/assets/images/arrow-down.svg`)" height="12" />
+          <img class="arrow-up" :src="require(`@/assets/images/arrow-up.svg`)" height="12" />
+          {{ paramName }}
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import { popQuery } from '@/utils'
+
+export default {
+  data() {
+    return {
+      sortingOptions: ['claps', 'name', 'updated'],
+    }
+  },
+  methods: {
+    getSortStyle(sortBy) {
+      const isActive = this.$route.query.sort == sortBy
+      const isReverse = this.$route.query.reverse
+      return (isActive ? 'active' : '') + ' ' + (isActive && isReverse ? 'reversed' : '')
+    },
+    handleSortChange(sortBy) {
+      const isAlready = Boolean(this.$route.query.sort == sortBy)
+      const isReversed = Boolean(this.$route.query.reverse)
+      if (isAlready && !isReversed) {
+        this.$router.replace({ query: { ...this.$route.query, reverse: 1 } }).catch(() => {})
+      } else if (isAlready && isReversed) {
+        popQuery(this.$router, this.$route.query, 'reverse')
+      } else {
+        this.$router.replace({ query: { ...this.$route.query, sort: sortBy } }).catch(() => {})
+        if (isReversed) {
+          popQuery(this.$router, this.$route.query, 'reverse')
+        }
+      }
+      // this.refetch()
+      this.$emit('sort')
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.sorting-options {
+  display: flex;
+  @include for-large-up {
+    justify-content: flex-end;
+  }
+  ul {
+    display: flex;
+  }
+  li {
+    text-decoration: underline;
+    text-decoration-color: $yellow;
+    &:not(:last-child) {
+      margin-right: 1rem;
+    }
+    display: flex;
+    align-items: center;
+    color: $light-gray;
+    img {
+      display: none;
+      margin-top: 0.15rem;
+    }
+    &.active {
+      color: $dark;
+      .arrow-down {
+        display: block;
+      }
+      .arrow-up {
+        display: none;
+      }
+    }
+    &.reversed {
+      color: $dark;
+      .arrow-down {
+        display: none;
+      }
+      .arrow-up {
+        display: block;
+      }
+    }
+  }
+}
+</style>

--- a/src/views/CompanyList.vue
+++ b/src/views/CompanyList.vue
@@ -32,7 +32,7 @@
 
       <!-- Sorting -->
       <div class="mt-1 mb-2">
-        <Sorting @sort="refetch" />
+        <Sorting :sorting-options="sortingOptions" @sort="refetch" />
       </div>
 
       <p class="mt-3 small">
@@ -101,6 +101,7 @@ export default {
       isLoading: true,
       searchQuery: '',
       initialQueryHashtags: [],
+      sortingOptions: ['claps', 'name', 'updated'],
     }
   },
   computed: {

--- a/src/views/CompanyList.vue
+++ b/src/views/CompanyList.vue
@@ -32,21 +32,7 @@
 
       <!-- Sorting -->
       <div class="mt-1 mb-2">
-        <label class="mt-1">Sorting</label>
-        <div class="sorting-options fill-x">
-          {{ $route.query.reverse ? '🔻' : '' }}
-          <ul>
-            <li
-              v-for="paramName in sortingOptions"
-              :key="paramName"
-              class="pointer small"
-              :class="getSortStyle(paramName)"
-              @click="handleSortChange(paramName)"
-            >
-              {{ paramName }}
-            </li>
-          </ul>
-        </div>
+        <Sorting @sort="refetch" />
       </div>
 
       <p class="mt-3 small">
@@ -73,6 +59,7 @@ import Button from '../components/forms/Button.vue'
 import Pagination from '../components/Pagination.vue'
 import HashtagInput from '../components/forms/HashtagInput.vue'
 import Loader from '../components/Loader.vue'
+import Sorting from '../components/Sorting.vue'
 import TextInput from '../components/forms/TextInput.vue'
 import api from '@/api'
 import CompanyCard from '@/components/CompanyCard'
@@ -88,6 +75,7 @@ export default {
   components: {
     CompanyCard,
     TextInput,
+    Sorting,
     Loader,
     HashtagInput,
     Button,
@@ -105,7 +93,6 @@ export default {
   },
   data() {
     return {
-      sortingOptions: ['claps', 'name', 'updated'],
       PAGE_SIZE: 10,
       numPages: 1,
       hasMore: false,
@@ -173,26 +160,6 @@ export default {
       this.refetch()
     }, 200),
 
-    getSortStyle(sortBy) {
-      let isActive = this.$route.query.sort == sortBy
-      let isReverse = this.$route.query.reverse
-      return (isActive ? 'active' : '') + ' ' + (isActive && isReverse ? 'reversed' : '')
-    },
-    handleSortChange(sortBy) {
-      let isAlready = Boolean(this.$route.query.sort == sortBy)
-      let isReversed = Boolean(this.$route.query.reverse)
-      if (isAlready && !isReversed) {
-        this.$router.replace({ query: { ...this.$route.query, reverse: 1 } }).catch(() => {})
-      } else if (isAlready && isReversed) {
-        popQuery(this.$router, this.$route.query, 'reverse')
-      } else {
-        this.$router.replace({ query: { ...this.$route.query, sort: sortBy } }).catch(() => {})
-        if (isReversed) {
-          popQuery(this.$router, this.$route.query, 'reverse')
-        }
-      }
-      this.refetch()
-    },
     handleHashtagFilterChanged(tags) {
       if (tags.length) {
         const hashtagStr = tags.join(',')
@@ -226,24 +193,6 @@ export default {
 .sidebar {
   @include for-large-up {
     text-align: right;
-  }
-}
-.sorting-options {
-  display: flex;
-  @include for-large-up {
-    justify-content: flex-end;
-  }
-  li {
-    text-decoration: underline;
-    text-decoration-color: $yellow;
-    &:not(:last-child) {
-      margin-right: 1rem;
-    }
-    display: inline-block;
-    color: $light-gray;
-    &.active {
-      color: $dark;
-    }
   }
 }
 </style>


### PR DESCRIPTION
From #75:
- Move Sorting to its own component
- Add sorted & reverse arrows to each item

---- 
This is the exact same PR, except `sortingOptions` is passed down as props.
the error was bcs `sortingOptions` was being referenced in `CompanyList`