### PR TITLE
clear items on page change

### DIFF
--- a/src/views/CompanyList.vue
+++ b/src/views/CompanyList.vue
@@ -184,6 +184,7 @@ export default {
 
     handlePageClick(pageNumber) {
       this.$router.replace({ query: { ...this.$route.query, page: pageNumber } })
+      this.items = []
       this.fetchItems(pageNumber)
     },
   },
@@ -209,5 +210,4 @@ export default {
   background-color: rgba(255, 255, 255, 0.8);
   padding-top: 4rem;
 }
-
 </style>


### PR DESCRIPTION
quick fix - just realized clearing list was helping with page navigation - 
eg. scrols up to top on page change.

Scroll to bottom, change to page 2.
w/out this, it stays at bottom.
w/ this it scrolls back up to top of new list  <- seems more inline "page turning"