### PR TITLE
Fixes bad cache hotfix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
     <Poopee />
     <SocialIcons />
     <transition name="fade" mode="out-in">
-      <keep-alive>
+      <keep-alive include="CompanyList">
         <router-view />
       </keep-alive>
     </transition>


### PR DESCRIPTION
keep-alive currently caches every view, so it's display wrong companies on return.
Should only maintain state of CompanyList

![image](https://user-images.githubusercontent.com/9513968/115911666-37afa280-a423-11eb-9393-dcd9f0f8d67c.png)
